### PR TITLE
Fix decoding of `paths` within `get_local_file_paths`

### DIFF
--- a/tap_singer_jsonl/utils.py
+++ b/tap_singer_jsonl/utils.py
@@ -35,7 +35,7 @@ def get_local_file_lines(config):
 
 
 def get_local_file_paths(config):
-    paths = config.get("paths", [])
+    paths = [Path(path) for path in config.get("paths", [])]
     recursive = config.get("recursive", False)
     if "folders" in config:
         for folder in config["folders"]:


### PR DESCRIPTION
Dear Ken,

this patch fixes a flaw when configured via Meltano like this:
```yaml
  - name: tap-singer-jsonl
    variant: kgpayne
    config:
      source: local
      add_record_metadata: false
      local:
        paths:
          - "tap_countries.singer"
```

In theory, it could also happen when configured by Singer tooling on behalf of a corresponding JSON snippet.

With kind regards,
Andreas.
